### PR TITLE
use local server when local, prod server when in prod

### DIFF
--- a/my-app/src/api-config.js
+++ b/my-app/src/api-config.js
@@ -1,0 +1,11 @@
+let baseURL;
+
+const hostname = window && window.location && window.location.hostname;
+
+if(hostname === 'localhost') {
+  baseURL = 'http://127.0.0.1:8000/';
+} else {
+  baseURL = 'https://jango-island-production.herokuapp.com'
+}
+
+export { baseURL }

--- a/my-app/src/libs/api.js
+++ b/my-app/src/libs/api.js
@@ -1,6 +1,6 @@
 import axios from "axios";
+import { baseURL } from '../api-config'
 
-const baseURL = "https://jango-island-production.herokuapp.com";
 const api = axios.create({ baseURL });
 
 export function login(data) {


### PR DESCRIPTION
this will prevent the prod db from being filled with too much garbage, and we wont have to reset it as much

when youre running the frontend locally, it'll use the local backend url. otherwise, if the frontend is running anywhere else (deploy preview url, prod url), it uses the heroku backend url

[Used this link](https://www.codeproject.com/Articles/1198138/Deploying-React-to-Multiple-Environments)